### PR TITLE
Fixed bulk handling of MasterSlave.

### DIFF
--- a/Kernel/System/DynamicField/Driver/MasterSlave.pm
+++ b/Kernel/System/DynamicField/Driver/MasterSlave.pm
@@ -156,7 +156,8 @@ sub EditFieldValueValidate {
     # perform necessary validations
     if ( $Param{Mandatory} && !$Value ) {
         return {
-            ServerError => 1,
+            ServerError  => $ServerError,
+            ErrorMessage => $ErrorMessage,
         };
     }
     else {


### PR DESCRIPTION
Currently bulk transactions are refused if no MasterSlave value other than "" is selected. 

Reason: Empty values are prohibited in Kernel/System/DynamicField/Driver/MasterSlave.pm

Testing showed that if empty values are allowed, no master or slave values get overwritten by submitting bulk actions with non filled MasterSlave field. 

To make it work again, pls. allow empty values.