### PR TITLE
Improved wording

### DIFF
--- a/Kernel/Config/Files/XML/OTRSMasterSlave.xml
+++ b/Kernel/Config/Files/XML/OTRSMasterSlave.xml
@@ -294,7 +294,7 @@
         </Value>
     </Setting>
     <Setting Name="Ticket::Frontend::AgentTicketMasterSlave###Title" Required="0" Valid="1">
-        <Description Translatable="1">Shows the title fields in the ticket MasterSlave screen of a zoomed ticket in the agent interface.</Description>
+        <Description Translatable="1">Shows the title field in the ticket MasterSlave screen of a zoomed ticket in the agent interface.</Description>
         <Navigation>Frontend::Agent::View::TicketMasterSlave</Navigation>
         <Value>
             <Item ValueType="Checkbox">0</Item>


### PR DESCRIPTION
Hi @carlosfrodriguez and @balazj 
There is only one title field, so plural form is superfluous. This was already fixed in the framework with https://github.com/OTRS/otrs/commit/42c93cb28b71d00beed385bd58e9efa0414d8850